### PR TITLE
feat: add preventScrollToFocusedMonth prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ staticRanges(`DefinedRange`, `DateRangePicker`)  | Array            | [default p
 inputRanges(`DefinedRange`, `DateRangePicker`)   | Array            | [default input ranges](https://github.com/iroomitapp/react-date-range/blob/master/src/defaultRanges.ts)             | -
 ariaLabels                           | Object    | {}               | inserts aria-label to inner elements
 dayContentRenderer                   | Function  | null             | Function to customize the rendering of Calendar Day. given a date is supposed to return what to render.
+preventScrollToFocusedMonth          | Boolean   | false            | When two or more months are open, prevent the shift of the focused month to the left.
 
  *shape of range:
  ```js

--- a/src/components/Calendar/index.tsx
+++ b/src/components/Calendar/index.tsx
@@ -64,7 +64,8 @@ export type CalendarProps = {
   fixedHeight?: boolean,
   calendarFocus?: "forwards" | "backwards",
   preventSnapRefocus?: boolean,
-  ariaLabels?: AriasLabelsType
+  ariaLabels?: AriasLabelsType,
+  preventScrollToFocusedMonth?: boolean
 };
 
 export default function Calendar({
@@ -111,6 +112,7 @@ export default function Calendar({
   calendarFocus = 'forwards',
   preventSnapRefocus = false,
   ariaLabels = {},
+  preventScrollToFocusedMonth = false
 }: CalendarProps) {
 
   const refs = React.useRef({
@@ -151,7 +153,9 @@ export default function Calendar({
       refs.current.ranges = ranges;
       refs.current.date = date;
 
-      updateShownDate();
+      if(!preventScrollToFocusedMonth) {
+        updateShownDate();
+      }
     }
 
     if (refs.current.dateOptions.locale != locale) {

--- a/src/components/DateRange/index.tsx
+++ b/src/components/DateRange/index.tsx
@@ -58,7 +58,8 @@ export default function DateRange({
   minDate,
   onRangeFocusChange,
   color,
-  previewRange
+  previewRange,
+  preventScrollToFocusedMonth
 }: DateRangeProps) {
 
   const refs = React.useRef({
@@ -242,6 +243,7 @@ export default function DateRange({
       maxDate={maxDate}
       minDate={minDate}
       color={color}
+      preventScrollToFocusedMonth={preventScrollToFocusedMonth}
     />
   )
 } 

--- a/src/components/DateRangePicker/index.tsx
+++ b/src/components/DateRangePicker/index.tsx
@@ -51,7 +51,8 @@ export default function DateRangePicker({
   minDate,
   monthDisplayFormat,
   months,
-  moveRangeOnFirstSelection
+  moveRangeOnFirstSelection,
+  preventScrollToFocusedMonth
 }: DateRangePickerProps) {
 
   const refs = React.useRef({
@@ -116,6 +117,7 @@ export default function DateRangePicker({
         monthDisplayFormat={monthDisplayFormat}
         months={months}
         moveRangeOnFirstSelection={moveRangeOnFirstSelection}
+        preventScrollToFocusedMonth={preventScrollToFocusedMonth}
       />
     </div>
   )


### PR DESCRIPTION
## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Description
I find it distracting that the calendar jumps when you have more than 1 month at a time displayed. This prop disables the shifting of the focused month to the left side.
