### PR TITLE
fix(Calendar): enable preview on drag move

### DIFF
--- a/src/components/Calendar/index.tsx
+++ b/src/components/Calendar/index.tsx
@@ -219,7 +219,7 @@ export default function Calendar({
       return;
     }
 
-    setState({ ...state, drag: { status: state.drag.status, range: { startDate: state.drag.range.startDate, endDate: date }, disablePreview: true } });
+    setState({ ...state, drag: { status: state.drag.status, range: { startDate: state.drag.range.startDate, endDate: date }, disablePreview: state.drag.disablePreview } });
   }
 
   const handleRangeFocusChange = (rangesIndex: number, rangeItemIndex: number) => {


### PR DESCRIPTION
## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Description
After dragging to select a date range, the preview for the next range is not displayed unless the user moves the cursor out of the calendar and then back in (or clicks on the calendar somewhere, not necessarily a date). This change enables the preview for the next range immediately.
