### PR TITLE
feat: focus next range on defined range click

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ inputRanges(`DefinedRange`, `DateRangePicker`)   | Array            | [default i
 ariaLabels                           | Object    | {}               | inserts aria-label to inner elements
 dayContentRenderer                   | Function  | null             | Function to customize the rendering of Calendar Day. given a date is supposed to return what to render.
 preventScrollToFocusedMonth          | Boolean   | false            | When two or more months are open, prevent the shift of the focused month to the left.
+focusNextRangeOnDefinedRangeClick    | Boolean  | false            | When a defined range is clicked, the next range will be focused
 
 #### Type DateRange:
  ```ts

--- a/src/components/DateRangePicker/index.tsx
+++ b/src/components/DateRangePicker/index.tsx
@@ -52,9 +52,9 @@ export default function DateRangePicker({
   monthDisplayFormat,
   months,
   moveRangeOnFirstSelection,
-  preventScrollToFocusedMonth
+  preventScrollToFocusedMonth,
+  focusNextRangeOnDefinedRangeClick
 }: DateRangePickerProps) {
-
   const refs = React.useRef({
     styles: generateStyles([Styles, classNames])
   });
@@ -63,7 +63,6 @@ export default function DateRangePicker({
     focusedRange: [findNextRangeIndex(ranges), 0],
     rangePreview: undefined
   });
-
 
   return (
     <div className={classnames(refs.current.styles.dateRangePickerWrapper, className)}>
@@ -75,9 +74,11 @@ export default function DateRangePicker({
         renderStaticRangeLabel={renderStaticRangeLabel}
         headerContent={headerContent}
         footerContent={footerContent}
+        focusNextRangeOnDefinedRangeClick={focusNextRangeOnDefinedRangeClick}
+        onRangeFocusChange={(focusedRange) => setState((s) => ({ ...s, focusedRange }))}
       />
       <DateRange
-        onRangeFocusChange={focusedRange => setState(s => ({...s, focusedRange}))}
+        onRangeFocusChange={(focusedRange) => setState((s) => ({ ...s, focusedRange }))}
         focusedRange={focusedRange || state.focusedRange}
         weekStartsOn={weekStartsOn}
         weekdayDisplayFormat={weekdayDisplayFormat}
@@ -120,6 +121,5 @@ export default function DateRangePicker({
         preventScrollToFocusedMonth={preventScrollToFocusedMonth}
       />
     </div>
-  )
-
+  );
 }

--- a/src/components/DefinedRange/index.tsx
+++ b/src/components/DefinedRange/index.tsx
@@ -4,6 +4,7 @@ import styles from '../../styles';
 import { defaultInputRanges, defaultStaticRanges } from '../../defaultRanges';
 import { DateRange } from '../DayCell';
 import InputRangeField from '../InputRangeField';
+import { findNextRangeIndex } from '../../utils';
 
 export type DefinedRangeProps = {
   inputRanges?: {label: string, range: (value: number) => DateRange, getCurrentValue: (range: DateRange) => number | "-" | "∞"}[],
@@ -14,9 +15,11 @@ export type DefinedRangeProps = {
   footerContent?: ReactElement,
   focusedRange?: number[],
   rangeColors?: string[],
+  focusNextRangeOnDefinedRangeClick?: boolean,
   onPreviewChange?: (value?: DateRange) => void,
   onChange?: (value: {[x: string]: DateRange}) => void,
   renderStaticRangeLabel?: (staticRange: DefinedRangeProps["staticRanges"][number]) => ReactElement
+  onRangeFocusChange?: (range: number[]) => void,
 };
 
 export default function DefinedRange({
@@ -28,9 +31,11 @@ export default function DefinedRange({
   rangeColors = ['#3d91ff', '#3ecf8e', '#fed14c'],
   ranges = [],
   focusedRange = [0, 0],
+  focusNextRangeOnDefinedRangeClick,
   onChange,
   onPreviewChange,
-  renderStaticRangeLabel
+  renderStaticRangeLabel,
+  onRangeFocusChange
 }: DefinedRangeProps) {
 
   const [state, setState] = React.useState({rangeOffset: 0, focusedInput: -1});
@@ -59,6 +64,11 @@ export default function DefinedRange({
     onChange({
       [selectedRange.key || `range${focusedRange[0] + 1}`]: { ...selectedRange, ...range },
     });
+
+    if (focusNextRangeOnDefinedRangeClick) {
+      const nextFocusRange = [findNextRangeIndex(ranges, focusedRange[0]), 0];
+      onRangeFocusChange?.(nextFocusRange);
+    }
   }
 
   const getRangeOptionValue = (option: DefinedRangeProps['inputRanges'][number]) => {


### PR DESCRIPTION
## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Description
I noticed that when I click on a defined range, the next range isn't focused. Maybe some people want the next range to be focused when they click on a defined range. This PR provides the user with a prop that enables this functionality. By default it is set to false to maintain the current behavior.
