### PR TITLE
fix menu month/year selector broken after change in 3.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iroomit/react-date-range",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "A React component for choosing dates and date ranges.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/components/Month/index.tsx
+++ b/src/components/Month/index.tsx
@@ -2,7 +2,7 @@ import React, { CSSProperties, MouseEvent, memo } from 'react';
 import { getMonthDisplayRange } from '../../utils';
 import { StylesType } from '../../styles';
 import DayCell, { DayCellProps, DateRange } from '../DayCell';
-import { FormatOptions, eachDayOfInterval, endOfDay, endOfWeek, format, isAfter, isBefore, isSameDay, isWeekend, isWithinInterval, startOfDay, startOfWeek } from 'date-fns';
+import { FormatOptions, eachDayOfInterval, endOfDay, endOfWeek, format, isAfter, isBefore, isSameDay, isWeekend, isWithinInterval, startOfDay, startOfMonth, startOfWeek } from 'date-fns';
 
 type MonthProps = {
   style: CSSProperties,
@@ -78,7 +78,13 @@ export default memo(function Month({
   const minDateInternal = !!minDate && startOfDay(minDate);
   const maxDateInternal = !!maxDate && endOfDay(maxDate);
 
-  const monthDisplay = getMonthDisplayRange(maxDate || month, dateOptions, fixedHeight);
+  let newMonthDisplayDate = month;
+
+  if (maxDate && (maxDate.getFullYear() < month.getFullYear() || (maxDate.getFullYear() == month.getFullYear() && maxDate.getMonth() < month.getMonth()))) {
+    newMonthDisplayDate = startOfMonth(maxDate);
+  }
+
+  const monthDisplay = getMonthDisplayRange(newMonthDisplayDate, dateOptions, fixedHeight);
 
   let rangesInternal = ranges;
 


### PR DESCRIPTION
## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [x ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Description
Fix bug introduced by change in 3.2.1 that causes the year and month selectors to stop working correctly.