### PR TITLE
favor shownDate before new Date() for focus

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -27,7 +27,7 @@ export function calcFocusDate(currentFocusedDate: Date, shownDate?: Date, date?:
       endDate: date,
     };
   }
-  targetInterval.startDate = startOfMonth(targetInterval.startDate || new Date());
+  targetInterval.startDate = startOfMonth(targetInterval.startDate || shownDate || new Date());
   targetInterval.endDate = endOfMonth(targetInterval.endDate || targetInterval.startDate);
   const targetDate = targetInterval.startDate || targetInterval.endDate || shownDate || new Date();
 


### PR DESCRIPTION
When we have a minDate + maxDate + shownDate, as soon as we empty the selected range the focus returns to new Date(), which can be outside of minDate/maxDate

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Description
Describe your pr here.

> Related Issue: #xxx